### PR TITLE
Add auth submit button loading states

### DIFF
--- a/docs/uiux/auth-submit-button-states.md
+++ b/docs/uiux/auth-submit-button-states.md
@@ -1,0 +1,16 @@
+# Auth Submit Button States
+
+Auth forms use `AuthSubmitButton` for primary submit actions across Login, Signup, and Forgot Password.
+
+## States
+
+- Idle: primary action text, enabled when the form can submit.
+- Loading: button is disabled, `aria-busy="true"` is set, and the visible label describes the pending action. The spinner is decorative.
+- Success: button remains disabled briefly while the success destination or confirmation view appears.
+
+## Accessibility
+
+- Loading state must be communicated with text, not only animation.
+- Disabled contrast uses the same primary token with reduced opacity.
+- Focus remains visible through the shared button focus ring.
+- Motion is disabled under `prefers-reduced-motion: reduce`.

--- a/src/components/AuthSubmitButton.test.tsx
+++ b/src/components/AuthSubmitButton.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { AuthSubmitButton } from './AuthSubmitButton';
+
+describe('AuthSubmitButton', () => {
+  it('renders the idle submit label', () => {
+    render(
+      <AuthSubmitButton
+        idleLabel="Sign In"
+        loadingLabel="Signing in..."
+        successLabel="Signed in"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeEnabled();
+  });
+
+  it('announces loading text and prevents double submission', () => {
+    render(
+      <AuthSubmitButton
+        state="loading"
+        idleLabel="Sign In"
+        loadingLabel="Signing in..."
+        successLabel="Signed in"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Signing in...' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('shows the success label while keeping the button disabled', () => {
+    render(
+      <AuthSubmitButton
+        state="success"
+        idleLabel="Create Account"
+        loadingLabel="Creating account..."
+        successLabel="Account created"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Account created' })).toBeDisabled();
+  });
+});

--- a/src/components/AuthSubmitButton.tsx
+++ b/src/components/AuthSubmitButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { CheckCircle, Loader2 } from 'lucide-react';
+
+export type SubmitButtonState = 'idle' | 'loading' | 'success';
+
+interface AuthSubmitButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  state?: SubmitButtonState;
+  idleLabel: string;
+  loadingLabel: string;
+  successLabel: string;
+}
+
+export const AuthSubmitButton: React.FC<AuthSubmitButtonProps> = ({
+  state = 'idle',
+  idleLabel,
+  loadingLabel,
+  successLabel,
+  className = '',
+  disabled,
+  ...buttonProps
+}) => {
+  const isLoading = state === 'loading';
+  const isSuccess = state === 'success';
+  const label = isLoading ? loadingLabel : isSuccess ? successLabel : idleLabel;
+
+  return (
+    <button
+      {...buttonProps}
+      type={buttonProps.type ?? 'submit'}
+      className={`btn-primary auth-submit-button auth-submit-button--${state} ${className}`.trim()}
+      disabled={disabled || isLoading || isSuccess}
+      aria-busy={isLoading}
+      data-state={state}
+    >
+      {isLoading && <Loader2 className="auth-submit-button__icon auth-submit-button__spinner" size={18} aria-hidden="true" />}
+      {isSuccess && <CheckCircle className="auth-submit-button__icon" size={18} aria-hidden="true" />}
+      <span>{label}</span>
+    </button>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -80,9 +80,44 @@ body {
   width: 100%;
 }
 
+.btn-primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.78;
+  transform: none;
+}
+
 .btn-primary:hover {
   background: var(--primary-hover);
   transform: translateY(-1px);
+}
+
+.btn-primary:disabled:hover {
+  background: var(--primary);
+  transform: none;
+}
+
+.auth-submit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 2.875rem;
+}
+
+.auth-submit-button--loading {
+  background: var(--primary-hover);
+}
+
+.auth-submit-button--success {
+  background: var(--success);
+}
+
+.auth-submit-button__icon {
+  flex-shrink: 0;
+}
+
+.auth-submit-button__spinner {
+  animation: auth-submit-spin 0.8s linear infinite;
 }
 
 .btn-primary:focus-visible,
@@ -253,3 +288,18 @@ input:focus-visible,
 .text-main { color: var(--text-main); }
 .text-success { color: var(--success); }
 .text-error { color: var(--error); }
+
+@keyframes auth-submit-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-primary,
+  .btn-secondary,
+  .auth-submit-button__spinner {
+    animation: none;
+    transition: none;
+  }
+}

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AuthLayout } from '../components/AuthLayout';
+import { AuthSubmitButton, SubmitButtonState } from '../components/AuthSubmitButton';
 import { Mail, ArrowLeft, AlertCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
@@ -7,15 +8,26 @@ export const ForgotPassword: React.FC = () => {
   const [email, setEmail] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [submitState, setSubmitState] = useState<SubmitButtonState>('idle');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitState === 'loading') return;
+
     if (!email.includes('@')) {
       setError('Please enter a valid email address.');
+      setSubmitState('idle');
       return;
     }
-    console.log('Password reset request:', email);
-    setSubmitted(true);
+
+    setError(null);
+    setSubmitState('loading');
+
+    window.setTimeout(() => {
+      console.log('Password reset request:', email);
+      setSubmitState('success');
+      window.setTimeout(() => setSubmitted(true), 350);
+    }, 500);
   };
 
   if (submitted) {
@@ -74,7 +86,12 @@ export const ForgotPassword: React.FC = () => {
           )}
         </div>
 
-        <button type="submit" className="btn-primary">Send Reset Link</button>
+        <AuthSubmitButton
+          state={submitState}
+          idleLabel="Send Reset Link"
+          loadingLabel="Sending reset link..."
+          successLabel="Reset link sent"
+        />
 
         <Link
           to="/login"

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AuthLayout } from '../components/AuthLayout';
+import { AuthSubmitButton, SubmitButtonState } from '../components/AuthSubmitButton';
 import { Mail, Lock, Wallet, Eye, EyeOff, AlertCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
@@ -8,12 +9,21 @@ export const Login: React.FC = () => {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [submitState, setSubmitState] = useState<SubmitButtonState>('idle');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('Login attempt:', { email, password });
-    // Mock login failure for UI demonstration
-    setError('Invalid email or password. Please try again.');
+    if (submitState === 'loading') return;
+
+    setError(null);
+    setSubmitState('loading');
+
+    window.setTimeout(() => {
+      console.log('Login attempt:', { email, password });
+      // Mock login failure for UI demonstration
+      setError('Invalid email or password. Please try again.');
+      setSubmitState('idle');
+    }, 500);
   };
 
   return (
@@ -86,7 +96,13 @@ export const Login: React.FC = () => {
           </div>
         </div>
 
-        <button type="submit" className="btn-primary mt-2">Sign In</button>
+        <AuthSubmitButton
+          className="mt-2"
+          state={submitState}
+          idleLabel="Sign In"
+          loadingLabel="Signing in..."
+          successLabel="Signed in"
+        />
 
         <div className="relative my-6 py-2 flex items-center">
           <div className="flex-grow border-t border-[rgba(148,163,184,0.1)]"></div>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AuthLayout } from '../components/AuthLayout';
+import { AuthSubmitButton, SubmitButtonState } from '../components/AuthSubmitButton';
 import { Mail, Lock, User, Briefcase, TrendingUp, Eye, EyeOff, AlertCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
@@ -13,6 +14,7 @@ export const Signup: React.FC = () => {
   const [name, setName] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitState, setSubmitState] = useState<SubmitButtonState>('idle');
 
   const handlePersonaSelect = (type: 'startup' | 'investor') => {
     setPersona(type);
@@ -21,6 +23,7 @@ export const Signup: React.FC = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitState === 'loading') return;
     
     // Mock validation
     const newErrors: Record<string, string> = {};
@@ -30,11 +33,18 @@ export const Signup: React.FC = () => {
     
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
+      setSubmitState('idle');
       return;
     }
 
-    console.log('Signup attempt:', { persona, name, email, password });
-    setStep('success');
+    setErrors({});
+    setSubmitState('loading');
+
+    window.setTimeout(() => {
+      console.log('Signup attempt:', { persona, name, email, password });
+      setSubmitState('success');
+      window.setTimeout(() => setStep('success'), 350);
+    }, 500);
   };
 
   if (step === 'success') {
@@ -175,7 +185,13 @@ export const Signup: React.FC = () => {
             <p id="password-hint" className="mt-2 text-[0.7rem] text-muted">Must be at least 12 characters with special characters.</p>
           </div>
 
-          <button type="submit" className="btn-primary mt-4">Create Account</button>
+          <AuthSubmitButton
+            className="mt-4"
+            state={submitState}
+            idleLabel="Create Account"
+            loadingLabel="Creating account..."
+            successLabel="Account created"
+          />
           
           <button 
             type="button" 


### PR DESCRIPTION
## Summary
- Adds a shared auth submit button component with idle, loading, and success states.
- Disables submit actions during loading and success states to prevent duplicate submissions.
- Adds visible text labels, icons, `aria-busy`, and reduced-motion handling for accessible feedback.
- Applies the states to login, signup, and forgot-password forms.
- Documents the state behavior in `docs/uiux/auth-submit-button-states.md`.

## Verification
- `npm run lint`
- `npm run build`
- `npm run test`

Closes #111