### PR TITLE
design: success/failure illustration set

### DIFF
--- a/docs/uiux/success-failure-illustrations.md
+++ b/docs/uiux/success-failure-illustrations.md
@@ -1,0 +1,74 @@
+# Success / Failure Illustrations (Design System)
+
+## Overview
+A paired illustration set for confirmation and error screens.
+
+## Illustration variants
+- `transactionSuccess` — transaction confirmed
+- `transactionFailure` — transaction failed
+- `kycApproved` — KYC approved
+- `kycRejected` — KYC rejected
+- `offeringPublished` — offering published
+
+## Component API
+
+```tsx
+import { SuccessFailureIllustration } from '@/components/designSystem/SuccessFailureIllustration';
+
+<SuccessFailureIllustration
+  variant="transactionSuccess"
+  size={96}
+  ariaHidden={true}
+/>
+```
+
+### Props
+- `variant` (required): one of the values above.
+- `size` (optional): renders a `96x96` SVG when omitted. Keep `>= 96px` for mobile legibility.
+- `ariaHidden` (optional):
+  - `true` (default): decorative SVG. Screen readers should use surrounding headline/body copy.
+  - `false`: SVG becomes meaningful content and receives an `aria-label`.
+
+## Pairing rules (headline + body microcopy)
+Illustrations should always be paired with explicit text.
+
+### Transaction success
+- Headline: “Transaction confirmed”
+- Body: “We’ve received your request. You can track updates from your activity page.”
+
+### Transaction failure
+- Headline: “Transaction failed”
+- Body: “No changes were made. Check your details and try again.”
+
+### KYC approved
+- Headline: “KYC approved”
+- Body: “Your verification is complete. You can continue to the next step.”
+
+### KYC rejected
+- Headline: “KYC needs attention”
+- Body: “Review the reason and submit corrected information.”
+
+### Offering published
+- Headline: “Offering published”
+- Body: “Your offering is live. Investors can now view and participate.”
+
+## Accessibility (WCAG 2.1 AA)
+- Default behavior: `ariaHidden={true}` so the SVG is decorative.
+- Provide a visible headline near the illustration.
+- For failures, ensure the surrounding container uses `role="alert"` / `aria-live="assertive"` where appropriate.
+- Color-blind safe: the illustration uses redundant shapes (check, X, shield, arrow), not color alone.
+
+## Dark mode
+The SVG uses design tokens (`--success`, `--error`) and semi-transparent fills so it remains readable in the app’s dark theme.
+
+## RTL mirroring
+No directional arrows are used for essential meaning; therefore no RTL flipping is required.
+
+## Reduced motion
+No animation is included inside the SVG.
+
+## Notes for reviewers (before/after)
+- Confirm legibility at `96px`.
+- Confirm that AT announcements come from headline/body (not the SVG).
+- Confirm contrast of the accent ring and glyph stroke against the dark glass background.
+

--- a/src/components/designSystem/SuccessFailureIllustration.test.tsx
+++ b/src/components/designSystem/SuccessFailureIllustration.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { SuccessFailureIllustration } from './SuccessFailureIllustration';
+
+describe('SuccessFailureIllustration', () => {
+  it('renders an SVG with expected size', () => {
+    const { container } = render(
+      <SuccessFailureIllustration variant="transactionSuccess" size={96} />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('width')).toBe('96');
+    expect(svg?.getAttribute('height')).toBe('96');
+  });
+
+  it('is aria-hidden by default (decorative)', () => {
+    const { container } = render(
+      <SuccessFailureIllustration variant="transactionSuccess" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('uses presentation role when ariaHidden=true', () => {
+    const { container } = render(
+      <SuccessFailureIllustration variant="transactionFailure" ariaHidden />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('role')).toBe('presentation');
+  });
+
+  it('renders with role img and aria-label when ariaHidden=false', () => {
+    const { container } = render(
+      <SuccessFailureIllustration variant="kycRejected" ariaHidden={false} />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('role')).toBe('img');
+    expect(svg?.getAttribute('aria-label')).toMatch(/KYC rejected/i);
+  });
+
+  it('renders distinct SVG paths for success vs failure (basic DOM sanity)', () => {
+    const success = render(
+      <SuccessFailureIllustration variant="transactionSuccess" />,
+    );
+    const failure = render(
+      <SuccessFailureIllustration variant="transactionFailure" />,
+    );
+
+    // Quick heuristic: both contain paths but success includes check path; failure includes two cross paths.
+    const successPaths = success.container.querySelectorAll('path').length;
+    const failurePaths = failure.container.querySelectorAll('path').length;
+    expect(successPaths).toBeGreaterThan(0);
+    expect(failurePaths).toBeGreaterThan(0);
+    expect(successPaths).not.toEqual(0);
+  });
+
+  const variants = [
+    'transactionSuccess',
+    'transactionFailure',
+    'kycApproved',
+    'kycRejected',
+    'offeringPublished',
+  ] as const;
+
+  it.each(variants)('accepts variant %s', (variant: (typeof variants)[number]) => {
+    const { container } = render(
+      <SuccessFailureIllustration variant={variant} ariaHidden={false} />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('aria-label')).toBeTruthy();
+  });
+});
+

--- a/src/components/designSystem/SuccessFailureIllustration.tsx
+++ b/src/components/designSystem/SuccessFailureIllustration.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type SuccessFailureIllustrationVariant =
+  | 'transactionSuccess'
+  | 'transactionFailure'
+  | 'kycApproved'
+  | 'kycRejected'
+  | 'offeringPublished';
+
+export type SuccessFailureIllustrationProps = {
+  /**
+   * Visual variant to render.
+   *
+   * Note: When used as decorative artwork, keep aria-hidden.
+   */
+  variant: SuccessFailureIllustrationVariant;
+  /**
+   * Pixel size (width/height). Must be >= 96px to meet the design requirement.
+   */
+  size?: number;
+  /**
+   * When the illustration is purely decorative, keep aria-hidden.
+   */
+  ariaHidden?: boolean;
+};
+
+const DEFAULT_SIZE = 96;
+
+/**
+ * Success / failure illustration set (SVG).
+ * - WCAG: artwork is decorative by default (aria-hidden)
+ * - Responsive: uses width/height from props; SVG stays legible at 96px
+ * - Dark-mode: uses currentColor + alpha fills
+ * - Color-blind safe: uses redundant shapes (check/x/shield/arrow) not color alone
+ */
+export const SuccessFailureIllustration: React.FC<SuccessFailureIllustrationProps> = ({
+  variant,
+  size = DEFAULT_SIZE,
+  ariaHidden = true,
+}) => {
+  const color = (() => {
+    switch (variant) {
+      case 'transactionSuccess':
+      case 'kycApproved':
+      case 'offeringPublished':
+        return 'var(--success)';
+      case 'transactionFailure':
+      case 'kycRejected':
+        return 'var(--error)';
+      default:
+        return 'currentColor';
+    }
+  })();
+
+  const label = (() => {
+    switch (variant) {
+      case 'transactionSuccess':
+        return 'Transaction successful';
+      case 'transactionFailure':
+        return 'Transaction failed';
+      case 'kycApproved':
+        return 'KYC approved';
+      case 'kycRejected':
+        return 'KYC rejected';
+      case 'offeringPublished':
+        return 'Offering published';
+      default:
+        return 'Status illustration';
+    }
+  })();
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 96 96"
+      role={ariaHidden ? 'presentation' : 'img'}
+      aria-hidden={ariaHidden}
+      aria-label={ariaHidden ? undefined : label}
+      focusable="false"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <filter id="ds-shadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0" dy="6" stdDeviation="6" floodColor="rgba(0,0,0,0.35)" />
+        </filter>
+      </defs>
+
+      {/* Outer badge (color-blind safe well) */}
+      <g filter="url(#ds-shadow)" transform="translate(48 48)">
+        <circle
+          r="44"
+          fill="rgba(255,255,255,0.02)"
+          stroke="rgba(148,163,184,0.25)"
+          strokeWidth="1.5"
+        />
+
+        {/* Icon well */}
+        <circle
+          r="30"
+          fill="rgba(255,255,255,0.01)"
+          stroke="rgba(148,163,184,0.16)"
+          strokeWidth="1.5"
+        />
+
+        {/* Decorative accent ring */}
+        <circle
+          r="30"
+          fill="none"
+          stroke={color}
+          strokeOpacity="0.28"
+          strokeWidth="4"
+          strokeDasharray="12 10"
+          transform="rotate(-15)"
+        />
+
+        {/* Variant glyph */}
+        {variant === 'transactionSuccess' && (
+          <SuccessGlyph color={color} />
+        )}
+        {variant === 'transactionFailure' && (
+          <FailureGlyph color={color} />
+        )}
+        {variant === 'kycApproved' && <KycApprovedGlyph color={color} />}
+        {variant === 'kycRejected' && <KycRejectedGlyph color={color} />}
+        {variant === 'offeringPublished' && <PublishedGlyph color={color} />}
+      </g>
+
+      {/* Small baseline caption dots (invisible to AT; improves shape complexity at 96px) */}
+      <g aria-hidden="true" opacity="0.25">
+        <circle cx="24" cy="82" r="1.5" fill={color} />
+        <circle cx="72" cy="82" r="1.5" fill={color} />
+      </g>
+    </svg>
+  );
+};
+
+const Stroke = ({ color }: { color: string }) => {
+  return {
+    stroke: color,
+    strokeWidth: 4,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    fill: 'none' as const,
+  };
+};
+
+const SuccessGlyph: React.FC<{ color: string }> = ({ color }) => {
+  // Check in a circle
+  return (
+    <g transform="translate(0 0)">
+      <circle cx="0" cy="0" r="18" fill="rgba(16,185,129,0.08)" stroke={color} strokeOpacity="0.45" strokeWidth="3" />
+      <path d="M-10 2 L-3 9 L12 -9" {...Stroke({ color })} />
+    </g>
+  );
+};
+
+const FailureGlyph: React.FC<{ color: string }> = ({ color }) => {
+  // X in a circle
+  return (
+    <g transform="translate(0 0)">
+      <circle cx="0" cy="0" r="18" fill="rgba(239,68,68,0.08)" stroke={color} strokeOpacity="0.45" strokeWidth="3" />
+      <path d="M-10 -8 L10 8" {...Stroke({ color })} />
+      <path d="M10 -8 L-10 8" {...Stroke({ color })} />
+    </g>
+  );
+};
+
+const KycApprovedGlyph: React.FC<{ color: string }> = ({ color }) => {
+  // Shield + check
+  return (
+    <g>
+      <path
+        d="M0 -20 C9 -16 15 -16 20 -14 V-2 C20 12 9 22 0 26 C-9 22 -20 12 -20 -2 V-14 C-15 -16 -9 -16 0 -20 Z"
+        fill="rgba(16,185,129,0.08)"
+        stroke={color}
+        strokeOpacity="0.6"
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+      <path d="M-10 2 L-2 10 L11 -8" {...Stroke({ color })} />
+    </g>
+  );
+};
+
+const KycRejectedGlyph: React.FC<{ color: string }> = ({ color }) => {
+  // Shield + X
+  return (
+    <g>
+      <path
+        d="M0 -20 C9 -16 15 -16 20 -14 V-2 C20 12 9 22 0 26 C-9 22 -20 12 -20 -2 V-14 C-15 -16 -9 -16 0 -20 Z"
+        fill="rgba(239,68,68,0.08)"
+        stroke={color}
+        strokeOpacity="0.6"
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+      <path d="M-10 -2 L10 14" {...Stroke({ color })} />
+      <path d="M10 -2 L-10 14" {...Stroke({ color })} />
+    </g>
+  );
+};
+
+const PublishedGlyph: React.FC<{ color: string }> = ({ color }) => {
+  // Arrow up + check badge
+  return (
+    <g>
+      <path d="M-6 10 L0 4 L6 10" {...Stroke({ color })} />
+      <path d="M0 -14 V2" {...Stroke({ color })} />
+      <path
+        d="M-14 -2 C-14 -14 -6 -18 0 -18 C6 -18 14 -14 14 -2 C14 10 6 18 0 18 C-6 18 -14 10 -14 -2 Z"
+        fill="rgba(56,189,248,0.06)"
+        stroke={color}
+        strokeOpacity="0.45"
+        strokeWidth="2.5"
+      />
+      <path d="M-6 -1 L-2 3 L8 -7" {...Stroke({ color })} />
+    </g>
+  );
+};
+
+export default SuccessFailureIllustration;
+


### PR DESCRIPTION
Closes #154 


Description
Confirmation and error full-screen pages currently use generic icons. Design a paired success/failure illustration set with brand-consistent style for transaction success, transaction failure, KYC approved, KYC rejected, and offering published.

Requirements and context
Must be accessible (WCAG 2.1 AA), responsive, and documented in the design system
Should be consistent with existing patterns and easy to review
Relevant code: src/components/ConfirmationNextSteps.tsx
Illustrations must remain legible at 96px on mobile and use color-blind safe accents
Suggested execution
Fork the repo and create a branch
git checkout -b uiux/success-failure-illustrations
Implement changes
Produce SVG illustrations and add to the design-system library
Document usage pairing with headline/body copy
Define dark-mode adaptive versions
Validate accessibility and responsive assumptions
Test and commit
Run checks
npm run lint and component/visual tests
Cover edge cases
Small viewport scaling, RTL mirroring rules, dark mode, reduced-motion (no animation)
Include screenshots/before-after and accessibility (axe) notes
Example commit message
design: success/failure illustration set

Guidelines