### PR TITLE
design: internationalization UX framework

### DIFF
--- a/docs/uiux/i18n-framework.md
+++ b/docs/uiux/i18n-framework.md
@@ -1,0 +1,89 @@
+# Internationalization UX Framework
+
+## Purpose
+This document defines the design system conventions for internationalization (i18n) across the Revora frontend. It covers copy-key naming, pluralization, locale-aware formatting, long-string handling, translator-friendly UI, and responsive accessibility.
+
+## Copy key conventions
+- Use dot-separated namespaces: `namespace.section.element`
+- Keep keys stable and content-agnostic: do not include punctuation, casing, or exact copy in the key name
+- Use kebab-case for key segments and avoid UI implementation references
+- Prefer semantic naming over verb/phrase fragments
+- Use placeholder tokens in copy, not string concatenation
+
+### Example key patterns
+- `auth.login.title`
+- `auth.login.subtitle`
+- `form.revenue.gross-revenue.label`
+- `form.revenue.payout-estimate.description`
+- `error.offering.network.message`
+
+## Pluralization conventions
+- Use ICU plural categories: `zero`, `one`, `two`, `few`, `many`, `other`
+- Do not build pluralized UI copy by concatenating runtime values
+- Use a helper that selects the correct form by locale and count
+- Keep plural forms close to the copy key and use placeholders for numbers
+
+### Example
+`{count, plural, one {# offering available} other {# offerings available}}`
+
+## Locale formatting
+All numeric, date, and currency display should use `Intl`-based locale formatting.
+
+### Supported locales and formats
+- `en-US`
+  - Date: `Apr 10, 2026`
+  - Number: `1,234.56`
+  - Currency: `$1,234`
+- `de-DE`
+  - Date: `10.4.2026`
+  - Number: `1.234,56`
+  - Currency: `1.234 €`
+- `ja-JP`
+  - Date: `2026/04/10`
+  - Number: `12,346`
+  - Currency: `￥1,234`
+- `ar-SA`
+  - Date: `١٠‏/٠٤‏/٢٠٢٦`
+  - Number: `١٬٢٣٥`
+  - Currency: `ر.س ١٬٢٣٤`
+
+### Implementation notes
+- Use `Intl.DateTimeFormat` with locale-specific date shape
+- Use `Intl.NumberFormat` for numbers and currency
+- Avoid manual string assembly for separators, symbols, or decimals
+
+## UI guidelines for copy expansion
+- Design all copy containers to support at least `+40%` localized expansion
+- Avoid fixed-width buttons and single-line labels that truncate long text
+- Use responsive layouts that stack or wrap rather than force horizontal compression
+- Allow `overflow-wrap: break-word` and `word-break: break-word`
+- Ensure `min-width: 0` on flex items containing text
+- Use multi-line copy for dense headings and button labels when necessary
+
+### Special language notes
+- German compounds can expand 30-40% in UI copy
+- Japanese does not use spaces, so avoid width-based truncation
+- Arabic requires right-to-left direction and natural punctuation ordering
+
+## Translator-friendly UI
+- Wrap translated copy in a component that uses `dir="auto"`
+- Expose `lang` when the locale is known
+- Show generated copy in context with actual layout boundaries
+- Avoid hiding copy behind icons, tooltips, or truncated content during translation review
+- Provide sample strings with placeholders to help translators avoid invalid token placement
+
+## Accessibility & responsiveness
+- Maintain WCAG 2.1 AA contrast on all translated text and labels
+- Use semantic markup and accessible roles for copy-heavy views
+- Prefer `aria-label` on icons and buttons over duplicate visible text for clarity
+- Keep line-length moderate and allow wrapping for long localized paragraphs
+- Validate new language support for both keyboard and screen reader workflows
+
+## Component design pattern
+- Use a reusable localized text wrapper for directionality and wrapping
+- Keep copy keys and runtime values separate
+- Provide a shared utility module for locale-specific formatting and plural selection
+- Document all supported locale behaviors in the design system
+
+## Summary
+This framework enables Revora UI to support internationalized copy consistently, safely, and accessibly. It formalizes translation key naming, locale formatting, plural rules, and responsive copy expansion so new UX work can be reviewed against a single system.

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -274,7 +275,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -323,7 +323,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1800,7 +1799,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1847,7 +1847,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1859,7 +1858,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1899,7 +1897,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2118,7 +2115,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -2263,7 +2259,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2304,6 +2299,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2591,7 +2587,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -2674,7 +2671,6 @@
       "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3220,7 +3216,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -3361,6 +3356,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3596,7 +3592,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3649,6 +3644,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3664,6 +3660,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3686,7 +3683,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3699,7 +3695,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3713,7 +3708,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.15.0",
@@ -4109,7 +4105,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4144,7 +4139,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4220,7 +4214,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",

--- a/src/components/LocalizedText.test.tsx
+++ b/src/components/LocalizedText.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LocalizedText } from "./LocalizedText";
+
+describe("LocalizedText", () => {
+  it("renders child text with the localized-text class", () => {
+    render(<LocalizedText>Copy example</LocalizedText>);
+    const node = screen.getByText("Copy example");
+    expect(node).toHaveClass("localized-text");
+    expect(node).toHaveAttribute("dir", "auto");
+  });
+
+  it("uses RTL direction for Arabic locale", () => {
+    render(<LocalizedText locale="ar-SA">مرحبا</LocalizedText>);
+    const node = screen.getByText("مرحبا");
+    expect(node).toHaveAttribute("dir", "rtl");
+  });
+
+  it("renders as a div when requested", () => {
+    render(
+      <LocalizedText as="div" locale="en-US">
+        Block copy
+      </LocalizedText>,
+    );
+    const node = screen.getByText("Block copy");
+    expect(node.tagName).toBe("DIV");
+  });
+});

--- a/src/components/LocalizedText.tsx
+++ b/src/components/LocalizedText.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { isRtlLocale, SupportedLocale } from "../constants/i18n";
+
+export interface LocalizedTextProps {
+  children: React.ReactNode;
+  locale?: SupportedLocale | string;
+  className?: string;
+  as?: "span" | "div";
+  role?: string;
+  id?: string;
+  lang?: string;
+}
+
+export const LocalizedText = React.forwardRef<HTMLElement, LocalizedTextProps>(
+  (
+    {
+      children,
+      locale,
+      className = "",
+      as = "span",
+      role,
+      id,
+      lang,
+    },
+    ref,
+  ) => {
+    const Tag = as as keyof JSX.IntrinsicElements;
+    const dir = locale ? (isRtlLocale(locale) ? "rtl" : "ltr") : "auto";
+
+    return (
+      <Tag
+        ref={ref as React.LegacyRef<HTMLElement>}
+        className={["localized-text", className].filter(Boolean).join(" ")}
+        dir={dir}
+        lang={lang ?? (locale as string | undefined)}
+        role={role}
+        id={id}
+      >
+        {children}
+      </Tag>
+    );
+  },
+);
+
+LocalizedText.displayName = "LocalizedText";

--- a/src/components/RevenueReportForm.tsx
+++ b/src/components/RevenueReportForm.tsx
@@ -1,5 +1,12 @@
 import { FormEvent, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { LocalizedText } from "./LocalizedText";
+import {
+  formatCurrency,
+  formatDate,
+  LOCALE_FORMAT_SETTINGS,
+  SupportedLocale,
+} from "../constants/i18n";
 import { TERMINOLOGY } from "../constants/terminology";
 
 const currencyOptions = [
@@ -8,24 +15,24 @@ const currencyOptions = [
   { value: "GBP", label: "GBP - British Pound" },
 ];
 
+const localeOptions: Array<{ value: SupportedLocale; label: string }> = (
+  Object.keys(LOCALE_FORMAT_SETTINGS) as SupportedLocale[]
+).map((locale) => ({
+  value: locale,
+  label: LOCALE_FORMAT_SETTINGS[locale].label,
+}));
+
 const reportPeriods = [
   { value: "2026-05", label: "May 2026" },
   { value: "2026-04", label: "April 2026" },
   { value: "2026-03", label: "March 2026" },
 ];
 
-const formatCurrency = (value: number, currency: string) => {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 0,
-  }).format(value);
-};
-
 export function RevenueReportForm() {
   const [reportPeriod, setReportPeriod] = useState(reportPeriods[0].value);
   const [grossRevenue, setGrossRevenue] = useState("");
   const [currency, setCurrency] = useState("USD");
+  const [locale, setLocale] = useState<SupportedLocale>(localeOptions[0].value);
   const [notes, setNotes] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submissionState, setSubmissionState] = useState<"idle" | "success" | "error">("idle");
@@ -41,7 +48,7 @@ export function RevenueReportForm() {
     return Math.round(revenueValue * 0.08);
   }, [revenueError, revenueValue]);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setSubmissionState("idle");
     setErrorMessage("");
@@ -67,15 +74,15 @@ export function RevenueReportForm() {
         <div className="glass-card p-8 md:p-10 space-y-8">
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
-              <p className="text-primary font-semibold uppercase tracking-[0.24em] text-xs">
+              <LocalizedText locale={locale} as="p" className="text-primary font-semibold uppercase tracking-[0.24em] text-xs">
                 Startup report
-              </p>
-              <h1 className="text-3xl md:text-4xl font-bold leading-tight">
+              </LocalizedText>
+              <LocalizedText locale={locale} as="h1" className="text-3xl md:text-4xl font-bold leading-tight">
                 Report monthly revenue for {TERMINOLOGY.revenueSharePayouts}
-              </h1>
-              <p className="text-muted max-w-2xl mt-3 text-sm md:text-base">
+              </LocalizedText>
+              <LocalizedText locale={locale} as="p" className="text-muted max-w-2xl mt-3 text-sm md:text-base">
                 Submit your gross monthly revenue and preview the estimated payout that will drive RevenueShare distributions.
-              </p>
+              </LocalizedText>
             </div>
             <Link to="/" className="btn-secondary sm:w-auto">
               Back to Home
@@ -150,6 +157,24 @@ export function RevenueReportForm() {
                 </div>
 
                 <div className="input-group">
+                  <label htmlFor="locale" className="input-label">
+                    Locale
+                  </label>
+                  <select
+                    id="locale"
+                    className="input-field"
+                    value={locale}
+                    onChange={(event) => setLocale(event.target.value as SupportedLocale)}
+                  >
+                    {localeOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="input-group">
                   <label htmlFor="notes" className="input-label">
                     Notes or attachments
                   </label>
@@ -198,19 +223,20 @@ export function RevenueReportForm() {
                 <div className="rounded-2xl bg-slate-950/60 p-4">
                   <p className="text-sm text-muted">Selected period</p>
                   <p className="mt-1 text-lg font-semibold">{reportPeriods.find((item) => item.value === reportPeriod)?.label}</p>
+                  <p className="text-xs text-muted">{formatDate(new Date(reportPeriod + "-01"), locale)}</p>
                 </div>
 
                 <div className="rounded-2xl bg-slate-950/60 p-4">
                   <p className="text-sm text-muted">Gross revenue</p>
                   <p className="mt-1 text-lg font-semibold">
-                    {revenueError ? "—" : formatCurrency(revenueValue, currency)}
+                    {revenueError ? "—" : formatCurrency(revenueValue, currency, locale)}
                   </p>
                 </div>
 
                 <div className="rounded-2xl bg-slate-950/60 p-4">
                   <p className="text-sm text-muted">Estimated payout</p>
                   <p className="mt-1 text-xl font-semibold text-success">
-                    {revenueError ? "Enter revenue to preview" : formatCurrency(payoutEstimate, currency)}
+                    {revenueError ? "Enter revenue to preview" : formatCurrency(payoutEstimate, currency, locale)}
                   </p>
                 </div>
               </div>

--- a/src/constants/i18n.test.ts
+++ b/src/constants/i18n.test.ts
@@ -1,0 +1,51 @@
+import {
+  buildTranslationKey,
+  formatCurrency,
+  formatDate,
+  formatNumber,
+  getPluralCategory,
+  isRtlLocale,
+  selectPluralForm,
+} from "./i18n";
+import { describe, expect, it } from "vitest";
+
+describe("i18n utility functions", () => {
+  it("builds stable translation keys from namespace segments", () => {
+    expect(buildTranslationKey("auth", "login", "title")).toBe("auth.login.title");
+  });
+
+  it("detects RTL locales", () => {
+    expect(isRtlLocale("ar-SA")).toBe(true);
+    expect(isRtlLocale("en-US")).toBe(false);
+  });
+
+  it("formats numbers for locale-specific display", () => {
+    expect(formatNumber(12345.678, "ja-JP")).toContain("12,346");
+    expect(formatNumber(12345.678, "de-DE")).toContain("12.345");
+  });
+
+  it("formats currency by locale and symbol", () => {
+    expect(formatCurrency(1200, "EUR", "de-DE")).toContain("€");
+    expect(formatCurrency(1200, "USD", "en-US")).toContain("$");
+  });
+
+  it("formats dates using locale settings", () => {
+    expect(formatDate("2026-05-10", "en-US")).toContain("2026");
+    expect(formatDate("2026-05-10", "de-DE")).toContain("2026");
+  });
+
+  it("returns correct plural categories for locales", () => {
+    expect(getPluralCategory("en-US", 1)).toBe("one");
+    expect(getPluralCategory("en-US", 5)).toBe("other");
+  });
+
+  it("selects the matching plural form fallback for locale counts", () => {
+    const forms = {
+      one: "1 offering available",
+      other: "{count} offerings available",
+    };
+
+    expect(selectPluralForm("en-US", 1, forms)).toBe("1 offering available");
+    expect(selectPluralForm("en-US", 3, forms)).toBe("{count} offerings available");
+  });
+});

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,0 +1,138 @@
+export const SUPPORTED_LOCALES = ["en-US", "de-DE", "ja-JP", "ar-SA"] as const;
+export type SupportedLocale = typeof SUPPORTED_LOCALES[number];
+
+export const TRANSLATION_KEY_CONVENTIONS = {
+  separator: ".",
+  example: "namespace.section.element",
+  rules: [
+    "Use dot-separated namespaces for distributed copy: auth.login.title, form.revenue.submit, error.offering.network",
+    "Keep keys stable and independent from wording changes: do not embed literal copy or punctuation in keys",
+    "Use lowercase, kebab-case segments and avoid UI implementation details in key names",
+    "Use noun-driven keys for static copy and verb-driven keys for actions",
+    "Place runtime parameters in placeholders, not in the key: report.accountSummary, not report.withTotal",
+  ] as const,
+};
+
+export const I18N_COPY_EXPANSION_RATIO = 1.4;
+export const RTL_LOCALES: SupportedLocale[] = ["ar-SA"];
+export const LOCALE_DIRECTION: Record<SupportedLocale, "ltr" | "rtl"> = {
+  "en-US": "ltr",
+  "de-DE": "ltr",
+  "ja-JP": "ltr",
+  "ar-SA": "rtl",
+};
+
+export type IcuPluralForms = {
+  zero?: string;
+  one: string;
+  two?: string;
+  few?: string;
+  many?: string;
+  other: string;
+};
+
+export const LOCALE_FORMAT_SETTINGS: Record<SupportedLocale, {
+  label: string;
+  date: Intl.DateTimeFormatOptions;
+  number: Intl.NumberFormatOptions;
+  currency: Intl.NumberFormatOptions;
+}> = {
+  "en-US": {
+    label: "English (United States)",
+    date: { year: "numeric", month: "short", day: "numeric" },
+    number: { maximumFractionDigits: 2 },
+    currency: { style: "currency", currency: "USD", currencyDisplay: "symbol", maximumFractionDigits: 0 },
+  },
+  "de-DE": {
+    label: "Deutsch (Deutschland)",
+    date: { year: "numeric", month: "numeric", day: "numeric" },
+    number: { maximumFractionDigits: 2 },
+    currency: { style: "currency", currency: "EUR", currencyDisplay: "symbol", maximumFractionDigits: 0 },
+  },
+  "ja-JP": {
+    label: "日本語 (日本)",
+    date: { year: "numeric", month: "numeric", day: "numeric" },
+    number: { maximumFractionDigits: 0, useGrouping: true },
+    currency: { style: "currency", currency: "JPY", currencyDisplay: "symbol", maximumFractionDigits: 0 },
+  },
+  "ar-SA": {
+    label: "العربية (السعودية)",
+    date: { year: "numeric", month: "numeric", day: "numeric" },
+    number: { maximumFractionDigits: 2, useGrouping: true },
+    currency: { style: "currency", currency: "SAR", currencyDisplay: "symbol", maximumFractionDigits: 0 },
+  },
+};
+
+export function buildTranslationKey(
+  namespace: string,
+  section: string,
+  element: string,
+): string {
+  return [namespace, section, element]
+    .filter(Boolean)
+    .map((segment) => segment.trim().toLowerCase().replace(/\s+/g, "-"))
+    .join(TRANSLATION_KEY_CONVENTIONS.separator);
+}
+
+export function isRtlLocale(locale: string): boolean {
+  return RTL_LOCALES.includes(locale as SupportedLocale);
+}
+
+export function formatNumber(
+  value: number,
+  locale: SupportedLocale = "en-US",
+  options: Intl.NumberFormatOptions = {},
+): string {
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 2,
+    useGrouping: true,
+    ...LOCALE_FORMAT_SETTINGS[locale].number,
+    ...options,
+  }).format(value);
+}
+
+export function formatCurrency(
+  value: number,
+  currency: string,
+  locale: SupportedLocale = "en-US",
+  options: Intl.NumberFormatOptions = {},
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    currencyDisplay: "symbol",
+    ...LOCALE_FORMAT_SETTINGS[locale].currency,
+    ...options,
+  }).format(value);
+}
+
+export function formatDate(
+  value: string | number | Date,
+  locale: SupportedLocale = "en-US",
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...LOCALE_FORMAT_SETTINGS[locale].date,
+    ...options,
+  }).format(new Date(value));
+}
+
+export function getPluralCategory(locale: SupportedLocale, count: number): string {
+  return new Intl.PluralRules(locale).select(count);
+}
+
+export function selectPluralForm(
+  locale: SupportedLocale,
+  count: number,
+  forms: IcuPluralForms,
+): string {
+  const category = getPluralCategory(locale, count) as keyof IcuPluralForms;
+  return forms[category] ?? forms.other;
+}
+
+export const I18N_ACCESSIBILITY_GUIDELINES = {
+  responsiveCopy: "Always allow localized copy to wrap and line-break without truncation. Avoid fixed-width buttons and headline containers that clip expanded values.",
+  translatorUI: "Render translation content with dir=\"auto\" and visible placeholder labels so translators can preview expanded strings in context.",
+  copyExpansion: "Design UI components to handle at least 40% copy expansion, especially for German compounds and Arabic RTL sentence structures.",
+  numericAccessibility: "Use locale-aware currency, number, and date formatting. Provide visible labels for currency and date context, not just symbols.",
+};

--- a/src/index.css
+++ b/src/index.css
@@ -355,6 +355,17 @@ input:focus-visible,
   border-radius: 0.25rem;
 }
 
+/* Localized text handling */
+.localized-text {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+}
+
+.localized-text[dir="rtl"] {
+  unicode-bidi: embed;
+}
+
 /* Utilities for accessibility and consistency */
 .text-primary {
   color: var(--primary);


### PR DESCRIPTION
closes #156 

## PR Summary

This PR adds an internationalization UX framework for Revora, including translation key conventions, locale-aware formatting utilities, long-copy handling guidance, and a translator-friendly text component.

## What changed

- Added i18n.ts
  - supported locale definitions: `en-US`, `de-DE`, `ja-JP`, `ar-SA`
  - locale direction mapping and RTL support
  - copy key / namespace conventions
  - plural category selection helpers
  - locale-aware date, number, and currency formatting utilities
  - copy-expansion and accessibility guidance constants

- Added i18n-framework.md
  - design system documentation for i18n conventions
  - guidelines for key naming, pluralization, locale formatting, copy expansion, and translator review

- Added LocalizedText.tsx
  - reusable wrapper for translated content
  - automatic `dir` selection and RTL-aware rendering

- Updated RevenueReportForm.tsx
  - added locale selector and locale-aware formatting
  - improved text rendering with `LocalizedText`
  - better support for long localized copy and responsive display

- Updated index.css
  - added localized text wrapping utilities
  - RTL-specific text handling support

- Added tests
  - i18n.test.ts
  - LocalizedText.test.tsx

## Validation

- `npx eslint i18n.ts LocalizedText.tsx src/components/RevenueReportForm.tsx` ✅
- `npx vitest run i18n.test.ts src/components/LocalizedText.test.tsx` ✅

## Notes

- A full repo `npm run lint && npm test` run hit an existing baseline failure in `InvestorDiscovery` unrelated to this i18n work (`ReferenceError: __simulateState is not defined`), so only the new i18n-focused files were validated end-to-end.