### PR TITLE
design: investor portfolio summary widgets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Login } from "./pages/Login";
 import { Signup } from "./pages/Signup";
 import { ForgotPassword } from "./pages/ForgotPassword";
 import { InvestorDiscovery } from "./components/InvestorDiscovery"; // Import here
+import { InvestorPortfolioSummary } from "./pages/InvestorPortfolioSummary";
 import { RevenueReportForm } from "./components/RevenueReportForm";
 import NotificationBell from "./components/Notifications/NotificationBell";
 import { notificationsMock } from "./components/Notifications/notificationsData";
@@ -28,6 +29,8 @@ export function App() {
 
           {/* Updated Route - Issue #63 */}
           <Route path="/investor/portal" element={<InvestorDiscovery />} />
+          {/* Issue #163 – Portfolio Summary */}
+          <Route path="/investor/portfolio" element={<InvestorPortfolioSummary />} />
         </Route>
       </Routes>
     </Router>

--- a/src/components/AllocationWidget.test.tsx
+++ b/src/components/AllocationWidget.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * AllocationWidget.test.tsx
+ * Issue #163 – Investor Portfolio Summary: allocation widget
+ * Coverage target ≥95% on AllocationWidget.tsx
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AllocationWidget, AllocationSlice } from "./AllocationWidget";
+
+const SLICES: AllocationSlice[] = [
+  { id: "1", label: "TechFlow AI", value: 45000, percentage: 45 },
+  { id: "2", label: "Quantum Ledger", value: 30000, percentage: 30 },
+  { id: "3", label: "Nexus Pay", value: 25000, percentage: 25 },
+];
+
+describe("AllocationWidget – empty state", () => {
+  it("renders allocation-widget testid", () => {
+    render(<AllocationWidget slices={[]} />);
+    expect(screen.getByTestId("allocation-widget")).toBeInTheDocument();
+  });
+
+  it("shows 'No holdings to display' when slices is empty", () => {
+    render(<AllocationWidget slices={[]} />);
+    expect(screen.getByText(/No holdings to display/i)).toBeInTheDocument();
+  });
+
+  it("does not render toggle buttons when empty", () => {
+    render(<AllocationWidget slices={[]} />);
+    expect(screen.queryByTestId("donut-toggle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bar-toggle")).not.toBeInTheDocument();
+  });
+});
+
+describe("AllocationWidget – donut view (default)", () => {
+  it("renders toggle group with accessible label", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByRole("group", { name: /Chart view toggle/i })).toBeInTheDocument();
+  });
+
+  it("donut toggle is initially aria-pressed=true", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByTestId("donut-toggle")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("bar toggle is initially aria-pressed=false", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByTestId("bar-toggle")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders svg with accessible label in donut view", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByRole("img", { name: /Donut chart showing portfolio allocation/i })).toBeInTheDocument();
+  });
+
+  it("renders legend list", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByRole("list", { name: /Allocation legend/i })).toBeInTheDocument();
+  });
+
+  it("legend shows all slice labels", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByText("TechFlow AI")).toBeInTheDocument();
+    expect(screen.getByText("Quantum Ledger")).toBeInTheDocument();
+    expect(screen.getByText("Nexus Pay")).toBeInTheDocument();
+  });
+
+  it("legend shows percentages", () => {
+    render(<AllocationWidget slices={SLICES} />);
+    expect(screen.getByText("45.0%")).toBeInTheDocument();
+    expect(screen.getByText("30.0%")).toBeInTheDocument();
+    expect(screen.getByText("25.0%")).toBeInTheDocument();
+  });
+});
+
+describe("AllocationWidget – bar view toggle", () => {
+  it("switches to bar view on click", async () => {
+    render(<AllocationWidget slices={SLICES} />);
+    await userEvent.click(screen.getByTestId("bar-toggle"));
+    expect(screen.getByTestId("bar-toggle")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("donut-toggle")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("bar view shows progressbars for each slice", async () => {
+    render(<AllocationWidget slices={SLICES} />);
+    await userEvent.click(screen.getByTestId("bar-toggle"));
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(SLICES.length);
+  });
+
+  it("bar progressbar has correct aria-valuenow", async () => {
+    render(<AllocationWidget slices={SLICES} />);
+    await userEvent.click(screen.getByTestId("bar-toggle"));
+    const first = screen.getAllByRole("progressbar")[0];
+    expect(first).toHaveAttribute("aria-valuenow", "45");
+  });
+
+  it("bar view shows all slice labels", async () => {
+    render(<AllocationWidget slices={SLICES} />);
+    await userEvent.click(screen.getByTestId("bar-toggle"));
+    expect(screen.getByText("TechFlow AI")).toBeInTheDocument();
+  });
+
+  it("can toggle back to donut from bar", async () => {
+    render(<AllocationWidget slices={SLICES} />);
+    await userEvent.click(screen.getByTestId("bar-toggle"));
+    await userEvent.click(screen.getByTestId("donut-toggle"));
+    expect(screen.getByRole("img", { name: /Donut chart/i })).toBeInTheDocument();
+  });
+
+  it("__initialView='bar' starts in bar view", () => {
+    render(<AllocationWidget slices={SLICES} __initialView="bar" />);
+    expect(screen.getByTestId("bar-toggle")).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+describe("AllocationWidget – single holding", () => {
+  it("renders without error with a single slice", () => {
+    render(
+      <AllocationWidget
+        slices={[{ id: "1", label: "Solo Fund", value: 10000, percentage: 100 }]}
+      />
+    );
+    expect(screen.getByText("Solo Fund")).toBeInTheDocument();
+    expect(screen.getByText("100.0%")).toBeInTheDocument();
+  });
+});
+
+describe("AllocationWidget – many holdings (overflow colours)", () => {
+  const many: AllocationSlice[] = Array.from({ length: 10 }, (_, i) => ({
+    id: String(i),
+    label: `Fund ${i + 1}`,
+    value: 1000,
+    percentage: 10,
+  }));
+
+  it("renders all 10 slices without error", () => {
+    render(<AllocationWidget slices={many} />);
+    expect(screen.getByText("Fund 10")).toBeInTheDocument();
+  });
+});

--- a/src/components/AllocationWidget.tsx
+++ b/src/components/AllocationWidget.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useId } from "react";
+import { PieChart, AlignLeft } from "lucide-react";
+
+export interface AllocationSlice {
+  id: string;
+  label: string;
+  value: number; // dollar amount
+  percentage: number; // 0-100
+}
+
+interface AllocationWidgetProps {
+  slices: AllocationSlice[];
+  /** Controlled view override (for tests) */
+  __initialView?: "donut" | "bar";
+}
+
+// Accessible colour palette — sufficient contrast on dark backgrounds
+const SLICE_COLOURS = [
+  "#3b82f6", // blue   (--primary)
+  "#10b981", // emerald
+  "#f59e0b", // amber
+  "#8b5cf6", // violet
+  "#ef4444", // red
+  "#06b6d4", // cyan
+  "#f97316", // orange
+  "#ec4899", // pink
+];
+
+function DonutChart({ slices }: { slices: AllocationSlice[] }) {
+  const size = 160;
+  const r = 60;
+  const cx = size / 2;
+  const cy = size / 2;
+  const circumference = 2 * Math.PI * r;
+  const gap = 2; // degrees gap between slices
+
+  // Build strokes from percentages
+  let cumulativePct = 0;
+  const segments = slices.map((s, i) => {
+    const pct = s.percentage;
+    const dashLen = (pct / 100) * circumference - (gap / 360) * circumference;
+    const offset = circumference - (cumulativePct / 100) * circumference;
+    cumulativePct += pct;
+    return { ...s, dashLen, offset, colour: SLICE_COLOURS[i % SLICE_COLOURS.length] };
+  });
+
+  const totalFormatted = slices.reduce((sum, s) => sum + s.value, 0).toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="relative" style={{ width: size, height: size }}>
+        <svg
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          role="img"
+          aria-label="Donut chart showing portfolio allocation"
+        >
+          {/* Background ring */}
+          <circle cx={cx} cy={cy} r={r} fill="none" stroke="rgba(148,163,184,0.1)" strokeWidth={22} />
+          {segments.map((seg) => (
+            <circle
+              key={seg.id}
+              cx={cx}
+              cy={cy}
+              r={r}
+              fill="none"
+              stroke={seg.colour}
+              strokeWidth={22}
+              strokeDasharray={`${seg.dashLen} ${circumference}`}
+              strokeDashoffset={seg.offset}
+              transform={`rotate(-90 ${cx} ${cy})`}
+              aria-label={`${seg.label}: ${seg.percentage.toFixed(1)}%`}
+            />
+          ))}
+        </svg>
+        {/* Center label */}
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center text-center pointer-events-none"
+          aria-hidden="true"
+        >
+          <span className="text-xs text-muted">Total</span>
+          <span className="text-sm font-bold">{totalFormatted}</span>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <ul className="w-full space-y-1.5" aria-label="Allocation legend">
+        {segments.map((seg) => (
+          <li key={seg.id} className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-2">
+              <span
+                className="inline-block rounded-full flex-shrink-0"
+                style={{ width: 10, height: 10, background: seg.colour }}
+                aria-hidden="true"
+              />
+              {seg.label}
+            </span>
+            <span className="font-medium">{seg.percentage.toFixed(1)}%</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function BarView({ slices }: { slices: AllocationSlice[] }) {
+  return (
+    <ul className="w-full space-y-3" aria-label="Portfolio allocation by issuer">
+      {slices.map((s, i) => {
+        const colour = SLICE_COLOURS[i % SLICE_COLOURS.length];
+        const formatted = s.value.toLocaleString("en-US", {
+          style: "currency",
+          currency: "USD",
+          maximumFractionDigits: 0,
+        });
+        return (
+          <li key={s.id} className="space-y-1">
+            <div className="flex justify-between text-xs">
+              <span>{s.label}</span>
+              <span className="font-medium">{formatted} ({s.percentage.toFixed(1)}%)</span>
+            </div>
+            <div
+              className="w-full rounded-full"
+              style={{ height: 8, background: "rgba(148,163,184,0.1)" }}
+              role="progressbar"
+              aria-valuenow={s.percentage}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${s.label}: ${s.percentage.toFixed(1)}%`}
+            >
+              <div
+                className="h-full rounded-full transition-all duration-500"
+                style={{ width: `${s.percentage}%`, background: colour }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export const AllocationWidget: React.FC<AllocationWidgetProps> = ({
+  slices,
+  __initialView = "donut",
+}) => {
+  const [view, setView] = useState<"donut" | "bar">(__initialView);
+  const toggleId = useId();
+
+  if (slices.length === 0) {
+    return (
+      <section className="glass-card p-6" aria-labelledby={`${toggleId}-heading`} data-testid="allocation-widget">
+        <h2 id={`${toggleId}-heading`} className="text-base font-semibold mb-4">Allocation</h2>
+        <p className="text-muted text-sm text-center py-8">No holdings to display.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="glass-card p-6 space-y-4" aria-labelledby={`${toggleId}-heading`} data-testid="allocation-widget">
+      <div className="flex items-center justify-between">
+        <h2 id={`${toggleId}-heading`} className="text-base font-semibold">Allocation</h2>
+        {/* Toggle between donut and bar */}
+        <div role="group" aria-label="Chart view toggle" className="flex items-center gap-1">
+          <button
+            className={`btn--icon p-1.5 rounded-md transition-colors ${view === "donut" ? "text-primary bg-primary/10" : "text-muted hover:text-main"}`}
+            onClick={() => setView("donut")}
+            aria-pressed={view === "donut"}
+            aria-label="Donut chart view"
+            data-testid="donut-toggle"
+          >
+            <PieChart size={16} aria-hidden="true" />
+          </button>
+          <button
+            className={`btn--icon p-1.5 rounded-md transition-colors ${view === "bar" ? "text-primary bg-primary/10" : "text-muted hover:text-main"}`}
+            onClick={() => setView("bar")}
+            aria-pressed={view === "bar"}
+            aria-label="Bar chart view"
+            data-testid="bar-toggle"
+          >
+            <AlignLeft size={16} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {view === "donut" ? <DonutChart slices={slices} /> : <BarView slices={slices} />}
+    </section>
+  );
+};

--- a/src/components/KpiHeader.test.tsx
+++ b/src/components/KpiHeader.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * KpiHeader.test.tsx
+ * Issue #163 – Investor Portfolio Summary: KPI header strip
+ * Coverage target ≥95% on KpiHeader.tsx
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import { KpiHeader } from "./KpiHeader";
+
+const defaultProps = {
+  totalInvested: "$100,000",
+  currentValue: "$103,000",
+  totalReturn: 3.0,
+  activeHoldings: 3,
+};
+
+describe("KpiHeader", () => {
+  it("renders with data-testid kpi-header", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getByTestId("kpi-header")).toBeInTheDocument();
+  });
+
+  it("renders section with accessible heading (sr-only)", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getByRole("heading", { name: /Portfolio Key Metrics/i })).toBeInTheDocument();
+  });
+
+  it("renders 4 kpi-card elements", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getAllByTestId("kpi-card")).toHaveLength(4);
+  });
+
+  it("renders aria-label on list", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getByRole("list", { name: /Portfolio key metrics/i })).toBeInTheDocument();
+  });
+
+  it("displays totalInvested value", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getByText("$100,000")).toBeInTheDocument();
+  });
+
+  it("displays currentValue value", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getByText("$103,000")).toBeInTheDocument();
+  });
+
+  it("displays formatted positive totalReturn", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getAllByText("+3.0%").length).toBeGreaterThan(0);
+  });
+
+  it("displays formatted negative totalReturn with minus sign", () => {
+    render(<KpiHeader {...{ ...defaultProps, totalReturn: -5.2 }} />);
+    expect(screen.getAllByText("-5.2%").length).toBeGreaterThan(0);
+  });
+
+  it("displays activeHoldings count", () => {
+    render(<KpiHeader {...defaultProps} />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows TrendingUp icon for positive return (aria-label)", () => {
+    render(<KpiHeader {...defaultProps} />);
+    // The change label on Current Value card contains aria-label with Increase
+    const cards = screen.getAllByTestId("kpi-card");
+    // Current Value card (index 1) has a change indicator
+    const currentValueCard = cards[1];
+    const changeEl = within(currentValueCard).getByText(/\+3\.0%/);
+    expect(changeEl).toBeInTheDocument();
+  });
+
+  it("shows TrendingDown for negative return", () => {
+    render(<KpiHeader {...{ ...defaultProps, totalReturn: -2.5 }} />);
+    // The aria-label on the change span references Decrease
+    const changeEls = screen.getAllByLabelText(/Decrease of 2.5%/i);
+    expect(changeEls.length).toBeGreaterThan(0);
+  });
+
+  it("renders with zero total return", () => {
+    render(<KpiHeader {...{ ...defaultProps, totalReturn: 0 }} />);
+    expect(screen.getAllByText("+0.0%").length).toBeGreaterThan(0);
+  });
+
+  it("renders with zero active holdings", () => {
+    render(<KpiHeader {...{ ...defaultProps, activeHoldings: 0 }} />);
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("renders with single holding", () => {
+    render(<KpiHeader {...{ ...defaultProps, activeHoldings: 1 }} />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+});

--- a/src/components/KpiHeader.tsx
+++ b/src/components/KpiHeader.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { TrendingUp, TrendingDown, DollarSign, BarChart2, Percent, Activity } from "lucide-react";
+
+export interface KpiItem {
+  id: string;
+  label: string;
+  value: string;
+  /** Optional change: positive = gain, negative = loss, undefined = neutral */
+  change?: number;
+  changeLabel?: string;
+}
+
+interface KpiHeaderProps {
+  totalInvested: string;
+  currentValue: string;
+  totalReturn: number; // percentage
+  activeHoldings: number;
+}
+
+function KpiCard({ label, value, change, changeLabel, icon }: KpiItem & { icon: React.ReactNode }) {
+  const isPositive = change !== undefined && change >= 0;
+  const isNegative = change !== undefined && change < 0;
+
+  return (
+    <div className="glass-card p-5 flex flex-col gap-2" data-testid="kpi-card">
+      <div className="flex items-center justify-between">
+        <span className="text-muted text-xs font-medium uppercase tracking-wide">{label}</span>
+        <span className="text-muted" aria-hidden="true">{icon}</span>
+      </div>
+      <span className="text-2xl font-bold tracking-tight">{value}</span>
+      {change !== undefined && (
+        <div
+          className={`flex items-center gap-1 text-xs font-medium ${isPositive ? "text-success" : "text-error"}`}
+          aria-label={`${changeLabel ?? (isPositive ? "Increase" : "Decrease")} of ${Math.abs(change)}%`}
+        >
+          {isPositive ? (
+            <TrendingUp size={13} aria-hidden="true" />
+          ) : (
+            <TrendingDown size={13} aria-hidden="true" />
+          )}
+          <span>{isPositive && !isNegative ? "+" : ""}{change.toFixed(1)}%</span>
+          {changeLabel && <span className="text-muted font-normal">{changeLabel}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const KpiHeader: React.FC<KpiHeaderProps> = ({
+  totalInvested,
+  currentValue,
+  totalReturn,
+  activeHoldings,
+}) => (
+  <section aria-labelledby="kpi-heading" data-testid="kpi-header">
+    <h2 id="kpi-heading" className="sr-only">Portfolio Key Metrics</h2>
+    <div
+      className="grid grid-cols-2 md:grid-cols-4 gap-4"
+      role="list"
+      aria-label="Portfolio key metrics"
+    >
+      <div role="listitem">
+        <KpiCard
+          id="total-invested"
+          label="Total Invested"
+          value={totalInvested}
+          icon={<DollarSign size={16} />}
+        />
+      </div>
+      <div role="listitem">
+        <KpiCard
+          id="current-value"
+          label="Current Value"
+          value={currentValue}
+          change={totalReturn}
+          changeLabel="overall"
+          icon={<BarChart2 size={16} />}
+        />
+      </div>
+      <div role="listitem">
+        <KpiCard
+          id="total-return"
+          label="Total Return"
+          value={`${totalReturn >= 0 ? "+" : ""}${totalReturn.toFixed(1)}%`}
+          change={totalReturn}
+          icon={<Percent size={16} />}
+        />
+      </div>
+      <div role="listitem">
+        <KpiCard
+          id="active-holdings"
+          label="Active Holdings"
+          value={String(activeHoldings)}
+          icon={<Activity size={16} />}
+        />
+      </div>
+    </div>
+  </section>
+);

--- a/src/components/PerformanceTrendWidget.test.tsx
+++ b/src/components/PerformanceTrendWidget.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * PerformanceTrendWidget.test.tsx
+ * Issue #163 – Investor Portfolio Summary: performance trend widget
+ * Coverage target ≥95% on PerformanceTrendWidget.tsx
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PerformanceTrendWidget, PerformanceDataPoint } from "./PerformanceTrendWidget";
+
+const DATA_12M: PerformanceDataPoint[] = [
+  { month: "Jul", value: 88000 },
+  { month: "Aug", value: 90500 },
+  { month: "Sep", value: 87000 },
+  { month: "Oct", value: 91200 },
+  { month: "Nov", value: 93400 },
+  { month: "Dec", value: 95000 },
+  { month: "Jan", value: 94100 },
+  { month: "Feb", value: 97300 },
+  { month: "Mar", value: 99800 },
+  { month: "Apr", value: 101500 },
+  { month: "May", value: 99200 },
+  { month: "Jun", value: 103000 },
+];
+
+const NEGATIVE_DATA: PerformanceDataPoint[] = [
+  { month: "Jan", value: 100000 },
+  { month: "Feb", value: 95000 },
+  { month: "Mar", value: 90000 },
+];
+
+describe("PerformanceTrendWidget – empty state", () => {
+  it("renders performance-widget testid", () => {
+    render(<PerformanceTrendWidget data={[]} />);
+    expect(screen.getByTestId("performance-widget")).toBeInTheDocument();
+  });
+
+  it("shows 'No performance data available' when empty", () => {
+    render(<PerformanceTrendWidget data={[]} />);
+    expect(screen.getByText(/No performance data available/i)).toBeInTheDocument();
+  });
+
+  it("does not render toggle buttons when empty", () => {
+    render(<PerformanceTrendWidget data={[]} />);
+    expect(screen.queryByTestId("chart-toggle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("table-toggle")).not.toBeInTheDocument();
+  });
+});
+
+describe("PerformanceTrendWidget – chart view (default)", () => {
+  it("renders section with heading", () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    expect(screen.getByRole("heading", { name: /12-Month Performance/i })).toBeInTheDocument();
+  });
+
+  it("chart toggle is initially aria-pressed=true", () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    expect(screen.getByTestId("chart-toggle")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("table toggle is initially aria-pressed=false", () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    expect(screen.getByTestId("table-toggle")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders SVG with accessible label", () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    expect(
+      screen.getByRole("img", { name: /12-month portfolio performance trend line chart/i })
+    ).toBeInTheDocument();
+  });
+
+  it("displays positive overall change badge", () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    // overall = (103000-88000)/88000 * 100 ≈ 17.0%
+    const badge = screen.getByLabelText(/Overall change/i);
+    expect(badge.textContent).toMatch(/\+/);
+  });
+
+  it("displays negative overall change for declining data", () => {
+    render(<PerformanceTrendWidget data={NEGATIVE_DATA} />);
+    const badge = screen.getByLabelText(/Overall change/i);
+    expect(badge.textContent).toMatch(/-/);
+  });
+});
+
+describe("PerformanceTrendWidget – table view", () => {
+  it("switches to table view on click", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    expect(screen.getByTestId("table-toggle")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("chart-toggle")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders accessible table", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    expect(screen.getByRole("table", { name: /12-month portfolio performance/i })).toBeInTheDocument();
+  });
+
+  it("table has column headers Month, Value, Change", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    expect(screen.getByRole("columnheader", { name: /Month/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Value/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Change/i })).toBeInTheDocument();
+  });
+
+  it("first row change column shows em-dash (no change from prior)", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("table rows show month labels", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    expect(screen.getByText("Jul")).toBeInTheDocument();
+    expect(screen.getByText("Jun")).toBeInTheDocument();
+  });
+
+  it("can toggle back to chart from table", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    await userEvent.click(screen.getByTestId("chart-toggle"));
+    expect(screen.getByRole("img", { name: /line chart/i })).toBeInTheDocument();
+  });
+
+  it("__initialView='table' starts in table view", () => {
+    render(<PerformanceTrendWidget data={DATA_12M} __initialView="table" />);
+    expect(screen.getByTestId("table-toggle")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("table")).toBeInTheDocument();
+  });
+});
+
+describe("PerformanceTrendWidget – edge cases", () => {
+  it("renders single data point without error", () => {
+    render(<PerformanceTrendWidget data={[{ month: "Jan", value: 50000 }]} />);
+    expect(screen.getByRole("img", { name: /line chart/i })).toBeInTheDocument();
+  });
+
+  it("handles flat data (all same value) without divide-by-zero", () => {
+    render(
+      <PerformanceTrendWidget
+        data={[
+          { month: "Jan", value: 100000 },
+          { month: "Feb", value: 100000 },
+        ]}
+      />
+    );
+    const badge = screen.getByLabelText(/Overall change/i);
+    expect(badge.textContent).toContain("0.0%");
+  });
+
+  it("renders with custom currency prop in table view", async () => {
+    render(<PerformanceTrendWidget data={DATA_12M} currency="EUR" __initialView="table" />);
+    // EUR formatting should appear in the table
+    const table = screen.getByRole("table");
+    expect(within(table).getAllByRole("cell").length).toBeGreaterThan(0);
+  });
+
+  it("negative period shows minus sign in change column", async () => {
+    render(<PerformanceTrendWidget data={NEGATIVE_DATA} />);
+    await userEvent.click(screen.getByTestId("table-toggle"));
+    // Second row should show negative change
+    const cells = screen.getAllByRole("cell");
+    const changeCell = cells.find((c) => c.textContent?.startsWith("-"));
+    expect(changeCell).toBeDefined();
+  });
+});

--- a/src/components/PerformanceTrendWidget.tsx
+++ b/src/components/PerformanceTrendWidget.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useId } from "react";
+import { LineChart, Table } from "lucide-react";
+
+export interface PerformanceDataPoint {
+  month: string; // e.g. "Jan", "Feb"
+  value: number; // portfolio value
+}
+
+interface PerformanceTrendWidgetProps {
+  data: PerformanceDataPoint[];
+  currency?: string;
+  /** Controlled view override (for tests) */
+  __initialView?: "chart" | "table";
+}
+
+function formatCurrency(value: number, currency = "USD") {
+  return value.toLocaleString("en-US", { style: "currency", currency, maximumFractionDigits: 0 });
+}
+
+function sparklinePath(points: { x: number; y: number }[]): string {
+  if (points.length === 0) return "";
+  return points.reduce((d, p, i) => d + (i === 0 ? `M ${p.x},${p.y}` : ` L ${p.x},${p.y}`), "");
+}
+
+function LineChartView({ data, currency }: { data: PerformanceDataPoint[]; currency?: string }) {
+  const W = 320;
+  const H = 120;
+  const padX = 8;
+  const padY = 12;
+
+  const values = data.map((d) => d.value);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal || 1;
+
+  const pts = data.map((d, i) => ({
+    x: padX + (i / Math.max(data.length - 1, 1)) * (W - 2 * padX),
+    y: H - padY - ((d.value - minVal) / range) * (H - 2 * padY),
+  }));
+
+  const path = sparklinePath(pts);
+  // Fill path: close at bottom-right and bottom-left
+  const fillPath = `${path} L ${pts[pts.length - 1].x},${H - padY} L ${pts[0].x},${H - padY} Z`;
+
+  const isPositive = data.length > 1 && data[data.length - 1].value >= data[0].value;
+  const lineColour = isPositive ? "var(--success, #10b981)" : "var(--error, #ef4444)";
+
+  return (
+    <div>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label="12-month portfolio performance trend line chart"
+        style={{ overflow: "visible" }}
+      >
+        <defs>
+          <linearGradient id="perf-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={lineColour} stopOpacity="0.2" />
+            <stop offset="100%" stopColor={lineColour} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        {/* Fill area */}
+        <path d={fillPath} fill="url(#perf-fill)" />
+        {/* Line */}
+        <path d={path} fill="none" stroke={lineColour} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+        {/* Data points */}
+        {pts.map((p, i) => (
+          <circle
+            key={i}
+            cx={p.x}
+            cy={p.y}
+            r={3}
+            fill={lineColour}
+            aria-label={`${data[i].month}: ${formatCurrency(data[i].value, currency)}`}
+          />
+        ))}
+        {/* X-axis month labels */}
+        {data.map((d, i) => (
+          <text
+            key={i}
+            x={pts[i].x}
+            y={H}
+            textAnchor="middle"
+            fontSize={9}
+            fill="var(--text-muted, #cbd5e1)"
+            aria-hidden="true"
+          >
+            {d.month}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function TableView({ data, currency }: { data: PerformanceDataPoint[]; currency?: string }) {
+  return (
+    <div className="overflow-x-auto" role="region" aria-label="Performance data table">
+      <table className="w-full text-sm" aria-label="12-month portfolio performance">
+        <thead>
+          <tr className="border-b border-[rgba(148,163,184,0.1)]">
+            <th scope="col" className="text-left text-xs text-muted font-medium pb-2">Month</th>
+            <th scope="col" className="text-right text-xs text-muted font-medium pb-2">Value</th>
+            <th scope="col" className="text-right text-xs text-muted font-medium pb-2">Change</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((d, i) => {
+            const prev = i > 0 ? data[i - 1].value : d.value;
+            const change = d.value - prev;
+            const changePct = prev !== 0 ? (change / prev) * 100 : 0;
+            const isPositive = change >= 0;
+            return (
+              <tr key={d.month} className="border-b border-[rgba(148,163,184,0.05)]">
+                <td className="py-1.5 text-xs">{d.month}</td>
+                <td className="py-1.5 text-xs text-right font-medium">{formatCurrency(d.value, currency)}</td>
+                <td className={`py-1.5 text-xs text-right ${i === 0 ? "text-muted" : isPositive ? "text-success" : "text-error"}`}>
+                  {i === 0 ? "—" : `${isPositive ? "+" : ""}${changePct.toFixed(1)}%`}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export const PerformanceTrendWidget: React.FC<PerformanceTrendWidgetProps> = ({
+  data,
+  currency = "USD",
+  __initialView = "chart",
+}) => {
+  const [view, setView] = useState<"chart" | "table">(__initialView);
+  const headingId = useId();
+
+  if (data.length === 0) {
+    return (
+      <section className="glass-card p-6" aria-labelledby={headingId} data-testid="performance-widget">
+        <h2 id={headingId} className="text-base font-semibold mb-4">12-Month Performance</h2>
+        <p className="text-muted text-sm text-center py-8">No performance data available.</p>
+      </section>
+    );
+  }
+
+  const first = data[0].value;
+  const last = data[data.length - 1].value;
+  const overallChange = first !== 0 ? ((last - first) / first) * 100 : 0;
+  const isPositive = overallChange >= 0;
+
+  return (
+    <section className="glass-card p-6 space-y-4" aria-labelledby={headingId} data-testid="performance-widget">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 id={headingId} className="text-base font-semibold">12-Month Performance</h2>
+          <span
+            className={`text-xs font-medium ${isPositive ? "text-success" : "text-error"}`}
+            aria-label={`Overall change: ${isPositive ? "+" : ""}${overallChange.toFixed(1)}%`}
+          >
+            {isPositive ? "+" : ""}{overallChange.toFixed(1)}% overall
+          </span>
+        </div>
+        <div role="group" aria-label="View toggle" className="flex items-center gap-1">
+          <button
+            className={`btn--icon p-1.5 rounded-md transition-colors ${view === "chart" ? "text-primary bg-primary/10" : "text-muted hover:text-main"}`}
+            onClick={() => setView("chart")}
+            aria-pressed={view === "chart"}
+            aria-label="Line chart view"
+            data-testid="chart-toggle"
+          >
+            <LineChart size={16} aria-hidden="true" />
+          </button>
+          <button
+            className={`btn--icon p-1.5 rounded-md transition-colors ${view === "table" ? "text-primary bg-primary/10" : "text-muted hover:text-main"}`}
+            onClick={() => setView("table")}
+            aria-pressed={view === "table"}
+            aria-label="Table view"
+            data-testid="table-toggle"
+          >
+            <Table size={16} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {view === "chart" ? (
+        <LineChartView data={data} currency={currency} />
+      ) : (
+        <TableView data={data} currency={currency} />
+      )}
+    </section>
+  );
+};

--- a/src/pages/InvestorPortfolioSummary.test.tsx
+++ b/src/pages/InvestorPortfolioSummary.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * InvestorPortfolioSummary.test.tsx
+ * Issue #163 – Investor Portfolio Summary page
+ * Coverage target ≥95% on InvestorPortfolioSummary.tsx
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { InvestorPortfolioSummary } from "./InvestorPortfolioSummary";
+import type { AllocationSlice } from "../components/AllocationWidget";
+import type { PerformanceDataPoint } from "../components/PerformanceTrendWidget";
+
+const ALLOCS: AllocationSlice[] = [
+  { id: "1", label: "TechFlow AI", value: 45000, percentage: 45 },
+  { id: "2", label: "Quantum Ledger", value: 30000, percentage: 30 },
+  { id: "3", label: "Nexus Pay", value: 25000, percentage: 25 },
+];
+
+const PERF: PerformanceDataPoint[] = [
+  { month: "Jan", value: 90000 },
+  { month: "Feb", value: 95000 },
+  { month: "Mar", value: 103000 },
+];
+
+const renderPage = (overrides = {}) =>
+  render(
+    <MemoryRouter>
+      <InvestorPortfolioSummary __allocations={ALLOCS} __performance={PERF} {...overrides} />
+    </MemoryRouter>
+  );
+
+describe("InvestorPortfolioSummary", () => {
+  it("renders portfolio-summary testid", () => {
+    renderPage();
+    expect(screen.getByTestId("portfolio-summary")).toBeInTheDocument();
+  });
+
+  it("renders page heading", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { level: 1, name: /Portfolio Summary/i })).toBeInTheDocument();
+  });
+
+  it("renders back navigation link to /investor/portal", () => {
+    renderPage();
+    const link = screen.getByRole("link", { name: /Back to Investor Discovery/i });
+    expect(link).toHaveAttribute("href", "/investor/portal");
+  });
+
+  it("renders KPI header", () => {
+    renderPage();
+    expect(screen.getByTestId("kpi-header")).toBeInTheDocument();
+  });
+
+  it("renders allocation widget", () => {
+    renderPage();
+    expect(screen.getByTestId("allocation-widget")).toBeInTheDocument();
+  });
+
+  it("renders performance widget", () => {
+    renderPage();
+    expect(screen.getByTestId("performance-widget")).toBeInTheDocument();
+  });
+
+  it("computes totalInvested from allocations", () => {
+    renderPage();
+    // 45000+30000+25000 = 100000 → $100,000 (appears in KPI + allocation bar)
+    expect(screen.getAllByText("$100,000").length).toBeGreaterThan(0);
+  });
+
+  it("shows currentValue = last performance point", () => {
+    renderPage();
+    // last point value = 103000 → $103,000
+    expect(screen.getByText("$103,000")).toBeInTheDocument();
+  });
+
+  it("shows activeHoldings = 3", () => {
+    renderPage();
+    // KPI header "3" for activeHoldings
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders with default mock data when no props given", () => {
+    render(
+      <MemoryRouter>
+        <InvestorPortfolioSummary />
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId("portfolio-summary")).toBeInTheDocument();
+    expect(screen.getByTestId("kpi-header")).toBeInTheDocument();
+  });
+
+  it("handles empty allocations gracefully", () => {
+    renderPage({ __allocations: [] });
+    // totalInvested = 0, currentValue = last perf value
+    expect(screen.getByTestId("portfolio-summary")).toBeInTheDocument();
+  });
+
+  it("handles empty performance gracefully (currentValue falls back to totalInvested)", () => {
+    renderPage({ __performance: [] });
+    expect(screen.getByTestId("portfolio-summary")).toBeInTheDocument();
+  });
+
+  it("handles single holding", () => {
+    renderPage({
+      __allocations: [{ id: "1", label: "Solo Fund", value: 10000, percentage: 100 }],
+    });
+    expect(screen.getByText("Solo Fund")).toBeInTheDocument();
+  });
+
+  it("renders subtitle text", () => {
+    renderPage();
+    expect(
+      screen.getByText(/Your holdings, allocation, and 12-month performance at a glance/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/InvestorPortfolioSummary.tsx
+++ b/src/pages/InvestorPortfolioSummary.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { KpiHeader } from "../components/KpiHeader";
+import { AllocationWidget, AllocationSlice } from "../components/AllocationWidget";
+import { PerformanceTrendWidget, PerformanceDataPoint } from "../components/PerformanceTrendWidget";
+
+// ─── Mock data (replace with real API call) ───────────────────────────────────
+
+const MOCK_ALLOCATIONS: AllocationSlice[] = [
+  { id: "1", label: "TechFlow AI", value: 45000, percentage: 45 },
+  { id: "2", label: "Quantum Ledger", value: 30000, percentage: 30 },
+  { id: "3", label: "Nexus Pay", value: 25000, percentage: 25 },
+];
+
+const MOCK_PERFORMANCE: PerformanceDataPoint[] = [
+  { month: "Jul", value: 88000 },
+  { month: "Aug", value: 90500 },
+  { month: "Sep", value: 87000 },
+  { month: "Oct", value: 91200 },
+  { month: "Nov", value: 93400 },
+  { month: "Dec", value: 95000 },
+  { month: "Jan", value: 94100 },
+  { month: "Feb", value: 97300 },
+  { month: "Mar", value: 99800 },
+  { month: "Apr", value: 101500 },
+  { month: "May", value: 99200 },
+  { month: "Jun", value: 103000 },
+];
+
+interface InvestorPortfolioSummaryProps {
+  /** Inject mock data for testing */
+  __allocations?: AllocationSlice[];
+  __performance?: PerformanceDataPoint[];
+}
+
+export const InvestorPortfolioSummary: React.FC<InvestorPortfolioSummaryProps> = ({
+  __allocations = MOCK_ALLOCATIONS,
+  __performance = MOCK_PERFORMANCE,
+}) => {
+  const totalInvested = __allocations.reduce((s, a) => s + a.value, 0);
+  const currentValue = __performance.length > 0 ? __performance[__performance.length - 1].value : totalInvested;
+  const totalReturn = totalInvested > 0 ? ((currentValue - totalInvested) / totalInvested) * 100 : 0;
+
+  const formatUSD = (n: number) =>
+    n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-8 animate-fade-in" data-testid="portfolio-summary">
+      {/* ── Back nav + page title ── */}
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <Link
+            to="/investor/portal"
+            className="inline-flex items-center gap-1 text-sm text-muted hover:text-main transition-colors mb-2"
+            aria-label="Back to Investor Discovery"
+          >
+            <ArrowLeft size={14} aria-hidden="true" />
+            Back to Discovery
+          </Link>
+          <h1 className="text-3xl font-bold tracking-tight">Portfolio Summary</h1>
+          <p className="text-muted text-sm mt-1">
+            Your holdings, allocation, and 12-month performance at a glance.
+          </p>
+        </div>
+      </div>
+
+      {/* ── KPI header strip ── */}
+      <KpiHeader
+        totalInvested={formatUSD(totalInvested)}
+        currentValue={formatUSD(currentValue)}
+        totalReturn={totalReturn}
+        activeHoldings={__allocations.length}
+      />
+
+      {/* ── Two-column widget area (stacks on mobile) ── */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <AllocationWidget slices={__allocations} />
+        <PerformanceTrendWidget data={__performance} />
+      </div>
+    </div>
+  );
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,9 +24,37 @@ export default defineConfig({
         'src/utils/passwordStrength.ts',
         'src/components/InvestorDiscovery.tsx',
         'src/components/InvestorDiscovery.test.tsx',
+        'src/components/KpiHeader.tsx',
+        'src/components/AllocationWidget.tsx',
+        'src/components/PerformanceTrendWidget.tsx',
+        'src/pages/InvestorPortfolioSummary.tsx',
       ],
       thresholds: {
         'src/components/InvestorDiscovery.tsx': {
+          branches: 95,
+          functions: 95,
+          lines: 95,
+          statements: 95,
+        },
+        'src/components/KpiHeader.tsx': {
+          branches: 95,
+          functions: 95,
+          lines: 95,
+          statements: 95,
+        },
+        'src/components/AllocationWidget.tsx': {
+          branches: 95,
+          functions: 95,
+          lines: 95,
+          statements: 95,
+        },
+        'src/components/PerformanceTrendWidget.tsx': {
+          branches: 95,
+          functions: 95,
+          lines: 95,
+          statements: 95,
+        },
+        'src/pages/InvestorPortfolioSummary.tsx': {
           branches: 95,
           functions: 95,
           lines: 95,


### PR DESCRIPTION
Closes #163 
- KpiHeader: 4-card KPI strip (total invested, current value, return %, holdings)
- AllocationWidget: SVG donut chart + accessible bar fallback with toggle
- PerformanceTrendWidget: sparkline + table fallback with 12-month data
- InvestorPortfolioSummary: responsive 2-column dashboard page at /investor/portfolio
- 66 tests, all passing; 95% coverage thresholds set for all new files
