### PR TITLE
design: session management and devices view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { DesignTokensPage } from "./pages/DesignTokens/DesignTokensPage";
 import { InvestorDiscovery } from "./components/InvestorDiscovery"; // Import here
 import { InvestorPortfolioSummary } from "./pages/InvestorPortfolioSummary";
 import { RevenueReportForm } from "./components/RevenueReportForm";
+import { SessionManagement } from "./components/SessionManagement/SessionManagement";
 import NotificationBell from "./components/Notifications/NotificationBell";
 import { notificationsMock } from "./components/Notifications/notificationsData";
 
@@ -32,6 +33,8 @@ export function App() {
           <Route path="/investor/portal" element={<InvestorDiscovery />} />
           {/* Issue #163 – Portfolio Summary */}
           <Route path="/investor/portfolio" element={<InvestorPortfolioSummary />} />
+          {/* Issue #169 – Session Management */}
+          <Route path="/settings/sessions" element={<SessionManagement />} />
         </Route>
       </Routes>
     </Router>

--- a/src/components/SessionManagement/SessionManagement.css
+++ b/src/components/SessionManagement/SessionManagement.css
@@ -1,0 +1,456 @@
+/* ─── Session Management Page ────────────────────────────────────────────────
+   WCAG 2.1 AA, responsive, consistent with Revora design tokens.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+.sm-container {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: var(--spacing-xl);
+}
+
+.sm-header {
+  margin-bottom: var(--spacing-2xl);
+}
+
+.sm-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3xs);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.2s ease;
+  margin-bottom: var(--spacing-sm);
+}
+
+.sm-back-link:hover {
+  color: var(--text-main);
+}
+
+.sm-back-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-xs);
+}
+
+.sm-title {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  color: var(--text-main);
+  margin: 0;
+}
+
+.sm-subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  margin-top: var(--spacing-xs);
+  line-height: var(--line-height-normal);
+}
+
+/* ─── Bulk Action ─────────────────────────────────────────────────────────── */
+
+.sm-bulk-action {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--spacing-lg);
+}
+
+/* ─── Session List ────────────────────────────────────────────────────────── */
+
+.sm-session-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+/* ─── Session Card ────────────────────────────────────────────────────────── */
+
+.sm-session-card {
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-xl);
+  transition: border-color 0.2s ease;
+}
+
+.sm-session-card--current {
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.04);
+}
+
+.sm-session-main {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+}
+
+.sm-session-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-lg);
+  background: var(--glass-bg-accent);
+  color: var(--text-muted);
+  flex-shrink: 0;
+  border: 1px solid var(--glass-border);
+}
+
+.sm-session-card--current .sm-session-icon {
+  color: var(--success);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.sm-session-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.sm-session-name-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-2xs);
+}
+
+.sm-session-name {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-main);
+}
+
+.sm-current-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--success);
+  background: rgba(16, 185, 129, 0.12);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.sm-session-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm) var(--spacing-lg);
+  margin-bottom: var(--spacing-2xs);
+}
+
+.sm-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3xs);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  line-height: var(--line-height-normal);
+}
+
+.sm-session-ip {
+  font-family: "SF Mono", "Monaco", "Menlo", monospace;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+.sm-session-action {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  margin-left: var(--spacing-sm);
+}
+
+.sm-current-hint {
+  display: flex;
+  align-items: center;
+  color: var(--success);
+}
+
+/* ─── Buttons ─────────────────────────────────────────────────────────────── */
+
+.sm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: 0.625rem 1.25rem;
+  border: none;
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.sm-btn:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.sm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sm-btn--destructive {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--error);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.sm-btn--destructive:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+.sm-btn--ghost-destructive {
+  background: transparent;
+  color: var(--text-muted);
+  padding: 0.5rem;
+  border-radius: var(--radius-md);
+  min-width: 2.5rem;
+}
+
+.sm-btn--ghost-destructive:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--error);
+}
+
+.sm-btn--secondary {
+  background: var(--glass-bg-accent);
+  color: var(--text-main);
+  border: 1px solid var(--glass-border);
+}
+
+.sm-btn--secondary:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.sm-btn--danger {
+  background: var(--error);
+  color: white;
+  border: 1px solid var(--error);
+}
+
+.sm-btn--danger:hover:not(:disabled) {
+  background: #dc2626;
+}
+
+/* ─── Empty State ─────────────────────────────────────────────────────────── */
+
+.sm-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--spacing-4xl) var(--spacing-xl);
+  color: var(--text-muted);
+  gap: var(--spacing-md);
+}
+
+.sm-empty-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-main);
+  margin: 0;
+}
+
+.sm-empty-text {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  max-width: 24rem;
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+}
+
+/* ─── Confirm Dialog ──────────────────────────────────────────────────────── */
+
+.sm-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: var(--spacing-md);
+  animation: smFadeIn 0.2s ease-out;
+}
+
+.sm-dialog {
+  width: 100%;
+  max-width: 420px;
+  padding: var(--spacing-2xl);
+  text-align: center;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: var(--glass-blur);
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-xl);
+}
+
+.sm-dialog-icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--error);
+  margin-bottom: var(--spacing-md);
+}
+
+.sm-dialog-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-main);
+  margin: 0 0 var(--spacing-sm);
+}
+
+.sm-dialog-message {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  line-height: var(--line-height-relaxed);
+  margin: 0 0 var(--spacing-xl);
+}
+
+.sm-dialog-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: center;
+}
+
+.sm-dialog-actions .sm-btn {
+  min-width: 8rem;
+}
+
+/* ─── Misc ────────────────────────────────────────────────────────────────── */
+
+.sm-single-session-note {
+  text-align: center;
+  margin-top: var(--spacing-lg);
+}
+
+/* ─── Screen Reader Only ──────────────────────────────────────────────────── */
+
+.sm-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .sm-container {
+    padding: var(--spacing-md);
+  }
+
+  .sm-title {
+    font-size: var(--font-size-2xl);
+  }
+
+  .sm-session-card {
+    padding: var(--spacing-md);
+  }
+
+  .sm-session-main {
+    flex-wrap: wrap;
+  }
+
+  .sm-session-meta {
+    flex-direction: column;
+    gap: var(--spacing-2xs);
+  }
+
+  .sm-session-action {
+    width: 100%;
+    margin-left: 0;
+    margin-top: var(--spacing-xs);
+    justify-content: flex-end;
+  }
+
+  .sm-hide-mobile {
+    display: none;
+  }
+
+  .sm-bulk-action {
+    justify-content: stretch;
+  }
+
+  .sm-bulk-action .sm-btn {
+    width: 100%;
+  }
+
+  .sm-dialog {
+    padding: var(--spacing-xl);
+  }
+
+  .sm-dialog-actions {
+    flex-direction: column;
+  }
+
+  .sm-dialog-actions .sm-btn {
+    min-width: auto;
+    width: 100%;
+  }
+}
+
+/* ─── Reduced Motion ──────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .sm-dialog-overlay {
+    animation: none;
+  }
+}
+
+/* ─── High Contrast ───────────────────────────────────────────────────────── */
+
+@media (prefers-contrast: high) {
+  .sm-dialog-overlay {
+    background: rgba(0, 0, 0, 0.85);
+  }
+
+  .sm-dialog {
+    border: 2px solid var(--text-main);
+  }
+
+  .sm-current-badge {
+    border: 1px solid var(--success);
+  }
+
+  .sm-btn--destructive {
+    border: 2px solid var(--error);
+  }
+
+  .sm-btn--danger {
+    border: 2px solid white;
+  }
+}
+
+/* ─── Animation ───────────────────────────────────────────────────────────── */
+
+@keyframes smFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/SessionManagement/SessionManagement.tsx
+++ b/src/components/SessionManagement/SessionManagement.tsx
@@ -1,0 +1,491 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  ArrowLeft,
+  Monitor,
+  Smartphone,
+  Laptop,
+  Globe,
+  Clock,
+  LogOut,
+  ShieldCheck,
+  AlertTriangle,
+} from "lucide-react";
+import "./SessionManagement.css";
+
+interface SessionDevice {
+  id: string;
+  deviceName: string;
+  deviceType: "desktop" | "mobile" | "tablet";
+  browser: string;
+  os: string;
+  ipAddress: string;
+  location: string;
+  lastActive: string;
+  isCurrent: boolean;
+}
+
+const MOCK_SESSIONS: SessionDevice[] = [
+  {
+    id: "sess-1",
+    deviceName: "MacBook Pro 16",
+    deviceType: "desktop",
+    browser: "Chrome 125",
+    os: "macOS 15.2",
+    ipAddress: "192.168.1.42",
+    location: "San Francisco, CA",
+    lastActive: "2026-06-26T10:30:00Z",
+    isCurrent: true,
+  },
+  {
+    id: "sess-2",
+    deviceName: "iPhone 16 Pro",
+    deviceType: "mobile",
+    browser: "Safari 18",
+    os: "iOS 19.0",
+    ipAddress: "203.0.113.45",
+    location: "San Francisco, CA",
+    lastActive: "2026-06-25T22:15:00Z",
+    isCurrent: false,
+  },
+  {
+    id: "sess-3",
+    deviceName: "Windows Desktop",
+    deviceType: "desktop",
+    browser: "Firefox 128",
+    os: "Windows 11",
+    ipAddress: "198.51.100.88",
+    location: "New York, NY",
+    lastActive: "2026-06-24T14:45:00Z",
+    isCurrent: false,
+  },
+  {
+    id: "sess-4",
+    deviceName: "iPad Air",
+    deviceType: "tablet",
+    browser: "Safari 18",
+    os: "iPadOS 19.0",
+    ipAddress: "203.0.113.102",
+    location: "Los Angeles, CA",
+    lastActive: "2026-06-20T09:00:00Z",
+    isCurrent: false,
+  },
+];
+
+function formatRelativeTime(isoString: string): string {
+  const now = Date.now();
+  const then = new Date(isoString).getTime();
+  const diffMs = now - then;
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMinutes < 1) return "Just now";
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return new Date(isoString).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatFullDate(isoString: string): string {
+  return new Date(isoString).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function DeviceIcon({ type }: { type: SessionDevice["deviceType"] }) {
+  switch (type) {
+    case "mobile":
+      return <Smartphone size={20} aria-hidden="true" />;
+    case "tablet":
+      return <Laptop size={20} aria-hidden="true" />;
+    default:
+      return <Monitor size={20} aria-hidden="true" />;
+  }
+}
+
+function SROnly({ children }: { children: React.ReactNode }) {
+  return <span className="sm-sr-only">{children}</span>;
+}
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+function ConfirmDialog({
+  isOpen,
+  title,
+  message,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  isLoading,
+}: ConfirmDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const FOCUSABLE_SELECTOR =
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus({ preventScroll: true });
+      previousFocusRef.current = null;
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !dialogRef.current) return;
+
+    const dialog = dialogRef.current;
+    const focusable = dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+
+      if (e.key === "Tab" && focusable.length > 0) {
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    dialog.addEventListener("keydown", handleKeyDown);
+    return () => dialog.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  useEffect(() => {
+    if (isOpen) {
+      const original = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = original;
+      };
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onCancel();
+  };
+
+  return (
+    <div
+      className="sm-dialog-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      onClick={handleOverlayClick}
+    >
+      <div className="sm-dialog glass-card" ref={dialogRef}>
+        <div className="sm-dialog-icon-wrap">
+          <AlertTriangle size={24} aria-hidden="true" />
+        </div>
+        <h2 id={titleId} className="sm-dialog-title">{title}</h2>
+        <p id={descriptionId} className="sm-dialog-message">{message}</p>
+        <div className="sm-dialog-actions">
+          <button
+            className="sm-btn sm-btn--secondary"
+            onClick={onCancel}
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            className="sm-btn sm-btn--danger"
+            onClick={onConfirm}
+            disabled={isLoading}
+            aria-busy={isLoading}
+          >
+            {isLoading ? "Revoking..." : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SessionManagementProps {
+  __initialSessions?: SessionDevice[];
+  __onRevokeSingle?: (sessionId: string) => Promise<void>;
+  __onRevokeAll?: () => Promise<void>;
+}
+
+export function SessionManagement({
+  __initialSessions = MOCK_SESSIONS,
+  __onRevokeSingle,
+  __onRevokeAll,
+}: SessionManagementProps) {
+  const [sessions, setSessions] = useState<SessionDevice[]>(__initialSessions);
+  const [dialogState, setDialogState] = useState<{
+    type: "single" | "all";
+    sessionId?: string;
+    deviceName?: string;
+  } | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokingAll, setRevokingAll] = useState(false);
+  const [announcement, setAnnouncement] = useState<string | null>(null);
+  const announceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const announce = useCallback((message: string) => {
+    setAnnouncement(message);
+    if (announceTimerRef.current) clearTimeout(announceTimerRef.current);
+    announceTimerRef.current = setTimeout(() => setAnnouncement(null), 3000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (announceTimerRef.current) clearTimeout(announceTimerRef.current);
+    };
+  }, []);
+
+  const handleRevokeSingle = useCallback(async () => {
+    if (!dialogState || dialogState.type !== "single" || !dialogState.sessionId) return;
+
+    const sessionId = dialogState.sessionId;
+    setRevokingId(sessionId);
+
+    if (__onRevokeSingle) {
+      await __onRevokeSingle(sessionId);
+    } else {
+      await new Promise((r) => setTimeout(r, 800));
+    }
+
+    setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    setRevokingId(null);
+    setDialogState(null);
+    announce(`Session for ${dialogState.deviceName || "device"} revoked`);
+  }, [dialogState, __onRevokeSingle, announce]);
+
+  const handleRevokeAll = useCallback(async () => {
+    setRevokingAll(true);
+
+    if (__onRevokeAll) {
+      await __onRevokeAll();
+    } else {
+      await new Promise((r) => setTimeout(r, 1200));
+    }
+
+    setSessions((prev) => prev.filter((s) => !s.isCurrent));
+    setRevokingAll(false);
+    setDialogState(null);
+    announce("Signed out of all other devices");
+  }, [__onRevokeAll, announce]);
+
+  const hasOtherSessions = sessions.some((s) => !s.isCurrent);
+
+  return (
+    <div className="sm-container animate-fade-in" data-testid="session-management">
+      {/* ── Live region for screen-reader announcements ── */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sm-sr-only"
+      >
+        {announcement}
+      </div>
+
+      {/* ── Page header ── */}
+      <div className="sm-header">
+        <Link
+          to="/"
+          className="sm-back-link"
+          aria-label="Back to Home"
+        >
+          <ArrowLeft size={14} aria-hidden="true" />
+          Back to Home
+        </Link>
+        <h1 className="sm-title">Session Management</h1>
+        <p className="sm-subtitle">
+          View and manage your active sessions across all devices.
+        </p>
+      </div>
+
+      {/* ── Sessions list ── */}
+      <section aria-label="Active sessions">
+        {sessions.length === 0 ? (
+          <div className="sm-empty" role="status">
+            <ShieldCheck size={48} aria-hidden="true" />
+            <h2 className="sm-empty-title">No active sessions</h2>
+            <p className="sm-empty-text">
+              All sessions have been signed out. Sign in again to create a new session.
+            </p>
+          </div>
+        ) : (
+          <>
+            {sessions.length > 1 && hasOtherSessions && (
+              <div className="sm-bulk-action">
+                <button
+                  className="sm-btn sm-btn--destructive"
+                  onClick={() => setDialogState({ type: "all" })}
+                  disabled={revokingAll}
+                  aria-busy={revokingAll}
+                >
+                  {revokingAll ? (
+                    "Signing out..."
+                  ) : (
+                    <>
+                      <LogOut size={16} aria-hidden="true" />
+                      Sign out of all other devices
+                    </>
+                  )}
+                </button>
+              </div>
+            )}
+
+            <ul className="sm-session-list" role="list">
+              {sessions.map((session) => {
+                const isRevoking = revokingId === session.id;
+                const canRevoke = !session.isCurrent && !isRevoking && !revokingAll;
+
+                return (
+                  <li
+                    key={session.id}
+                    className={`sm-session-card glass-card${session.isCurrent ? " sm-session-card--current" : ""}`}
+                    data-testid={`session-${session.id}`}
+                  >
+                    <div className="sm-session-main">
+                      <div className="sm-session-icon" aria-hidden="true">
+                        <DeviceIcon type={session.deviceType} />
+                      </div>
+
+                      <div className="sm-session-info">
+                        <div className="sm-session-name-row">
+                          <span className="sm-session-name">{session.deviceName}</span>
+                          {session.isCurrent && (
+                            <span className="sm-current-badge">
+                              Current session
+                            </span>
+                          )}
+                        </div>
+
+                        <div className="sm-session-meta">
+                          <span className="sm-meta-item">
+                            <Monitor size={12} aria-hidden="true" />
+                            {session.browser} on {session.os}
+                          </span>
+                          <span className="sm-meta-item">
+                            <Globe size={12} aria-hidden="true" />
+                            {session.location}
+                          </span>
+                          <span className="sm-meta-item">
+                            <Clock size={12} aria-hidden="true" />
+                            <span
+                              aria-label={`Last active ${formatFullDate(session.lastActive)}`}
+                            >
+                              {formatRelativeTime(session.lastActive)}
+                            </span>
+                          </span>
+                        </div>
+
+                        <div className="sm-session-ip sm-meta-item">
+                          IP: {session.ipAddress}
+                        </div>
+                      </div>
+
+                      <div className="sm-session-action">
+                        {session.isCurrent ? (
+                          <span className="sm-current-hint" aria-label="This is your current session">
+                            <ShieldCheck size={16} aria-hidden="true" />
+                          </span>
+                        ) : (
+                          <button
+                            className="sm-btn sm-btn--ghost-destructive"
+                            onClick={() =>
+                              setDialogState({
+                                type: "single",
+                                sessionId: session.id,
+                                deviceName: session.deviceName,
+                              })
+                            }
+                            disabled={!canRevoke}
+                            aria-label={`Revoke session for ${session.deviceName}`}
+                          >
+                            {isRevoking ? (
+                              "Revoking..."
+                            ) : (
+                              <>
+                                <LogOut size={14} aria-hidden="true" />
+                                <span className="sm-hide-mobile">Revoke</span>
+                              </>
+                            )}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {!hasOtherSessions && sessions.length === 1 && (
+              <p className="sm-single-session-note text-muted text-sm mt-4 text-center">
+                Only your current session is active.
+              </p>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* ── Confirm Dialog ── */}
+      {dialogState?.type === "single" && (
+        <ConfirmDialog
+          isOpen
+          title="Revoke session?"
+          message={`This will sign out "${dialogState.deviceName}" immediately. You may need to sign in again on that device.`}
+          confirmLabel="Revoke"
+          onConfirm={handleRevokeSingle}
+          onCancel={() => setDialogState(null)}
+          isLoading={revokingId !== null}
+        />
+      )}
+
+      {dialogState?.type === "all" && (
+        <ConfirmDialog
+          isOpen
+          title="Sign out everywhere?"
+          message="This will sign out all other active sessions. Your current session will remain active."
+          confirmLabel="Sign out everywhere"
+          onConfirm={handleRevokeAll}
+          onCancel={() => setDialogState(null)}
+          isLoading={revokingAll}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #169

## Summary
Implements the Session Management and Active Devices settings view with:
- Device listing with icons (desktop/mobile/tablet), browser/OS info, location, last active timestamp, and IP address
- Current session badge indicator
- Per-row Revoke action with destructive confirm dialog
- "Sign out of all other devices" bulk action
- Empty state when no sessions remain
- Screen reader live region for action announcements
- WCAG 2.1 AA compliance (focus trapping, ARIA roles, keyboard navigation, high contrast support, reduced motion)

## Implementation Details
- Route: `/settings/sessions`
- Component: `src/components/SessionManagement/SessionManagement.tsx`
- Styles: `src/components/SessionManagement/SessionManagement.css`
- Uses the existing `glass-card` pattern and design tokens
- Confirm dialog with focus trap and Escape-to-close (same pattern as KeyboardShortcutsOverlay)
- Responsive: stack layout on mobile, row layout on desktop
- Mock data for 4 devices (current session + 3 others)